### PR TITLE
change in ProcessHandle::alive, if already checked that the process is not running.

### DIFF
--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -146,6 +146,12 @@ Spawner::ProcessHandle::ProcessHandle(Deployment *deploment, bool redirectOutput
 
 bool Spawner::ProcessHandle::alive() const
 {
+    //if it was already determined before that the process is already dead,
+    //we can stop here. Otherwise waitpid would fail!
+    if(!isRunning){
+        return isRunning;
+    }
+
     int status = 0;
     pid_t ret = waitpid(pid, &status, WNOHANG);
     


### PR DESCRIPTION
Prevent from calling waitpid again with non
existing pid -> would fail otherwise.
