### PR TITLE
Solves the issue of inverted transformations in the transformer

### DIFF
--- a/src/TransformerHelper.cpp
+++ b/src/TransformerHelper.cpp
@@ -36,16 +36,18 @@ bool TransformerHelper::configureTransformer(RTT::TaskContext* task)
     for(const auto tr : robotConfiguration.getStaticTransforms())
     {
         base::samples::RigidBodyState transform;
-        transform.sourceFrame = tr->getSourceFrame().getName();
-        transform.targetFrame = tr->getTargetFrame().getName();
+        // NOTE: In the smurf loader classes source and target frame is interpreted the other way around. The transformation however is the same.
+        transform.sourceFrame = tr->getTargetFrame().getName();
+        transform.targetFrame = tr->getSourceFrame().getName();
         transform.setTransform(tr->getTransformation());
-        tree.addTransformation(new transformer::StaticTransformationElement(tr->getSourceFrame().getName(), tr->getTargetFrame().getName(), transform));
+        tree.addTransformation(new transformer::StaticTransformationElement(tr->getTargetFrame().getName(), tr->getSourceFrame().getName(), transform));
         staticTransforms.push_back(transform);
     }
     
     for(const auto tr : robotConfiguration.getDynamicTransforms())
     {
-        tree.addTransformation(new TransformationProvider(tr->getSourceFrame().getName(), tr->getTargetFrame().getName(), tr->getProviderName(), tr->getProviderPortName()));
+        // NOTE: In the smurf loader classes source and target frame is interpreted the other way around. The transformation however is the same.
+        tree.addTransformation(new TransformationProvider(tr->getTargetFrame().getName(), tr->getSourceFrame().getName(), tr->getProviderName(), tr->getProviderPortName()));
     }
 
     RTT::base::PortInterface *dynamicTransformsPort = task->getPort("dynamic_transformations");


### PR DESCRIPTION
TL/DR: In the smurf loader source and target frame is interpreted the other way around.

URDF: stores the pose of a child link in the parent link. E.g. Laser In Body
smurf loader: stores the pose of the target frame in the source frame. E.g. Laser In Body
Rock transformer: stores the pose of the source frame in the target frame. E.g. Laser In Body
Meaning the transformation is always the same, but the naming of what is source and what is target changes from smurf to rock.
