### PR TITLE
Spawner: Allow to control log folder. Allow execution of Spawner with…

### DIFF
--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -69,8 +69,7 @@ void shutdownHandler(int signum, siginfo_t *info, void *data)
 
 Spawner::Spawner()
 {
-    //log dir always exists if requested from bundle
-    logDir = Bundle::getInstance().getLogDirectory();
+    logDir = "";
 
     nameService = new CorbaNameService();
     nameService->connect();
@@ -92,6 +91,16 @@ Spawner& Spawner::getInstace()
     }
     
     return *instance;
+}
+
+void Spawner::setLogDir(std::string logDir)
+{
+    this->logDir = logDir;
+}
+
+void Spawner::setLogDirFromBundle()
+{
+    this->logDir = Bundle::getInstance().getLogDirectory();
 }
 
 

--- a/src/Spawner.hpp
+++ b/src/Spawner.hpp
@@ -53,6 +53,16 @@ public:
      * the spawner.
      * */
     static Spawner &getInstace();
+
+    /**
+     * Set directory for logfiles to the given path
+     */
+    void setLogDir(std::string logDir);
+
+    /**
+     * Set directory for logfiles from the currently dselected bundle
+     */
+    void setLogDirFromBundle();
     
     /**
      * This method spawns a default deployment matching the given componente description.


### PR DESCRIPTION
…out selected bundle.

Introduces API functions to set the log folder and removes calling the bundle mechanism in constructor, what allows to use without a selected bundle.