### PR TITLE
Allow bundle free log handling

### DIFF
--- a/src/LoggingHelper.cpp
+++ b/src/LoggingHelper.cpp
@@ -143,6 +143,13 @@ bool LoggingHelper::logTasks(const std::vector< std::string >& excludeList)
 
 bool LoggingHelper::logAllPorts(RTT::TaskContext* givenContext, const std::string& loggerName, const std::vector< std::string > excludeList, bool loadTypekits)
 {
+    Bundle &bundle(Bundle::getInstance());
+    return logAllPorts(givenContext, loggerName, bundle.getLogDirectory(), excludeList, loadTypekits);
+}
+
+bool LoggingHelper::logAllPorts(RTT::TaskContext* givenContext, const std::string& loggerName, const std::string& log_directory,
+                                const std::vector< std::string > excludeList, bool loadTypekits)
+{
     RTT::TaskContext* context = givenContext;
     std::string taskName = context->getName();
     
@@ -230,7 +237,7 @@ bool LoggingHelper::logAllPorts(RTT::TaskContext* givenContext, const std::strin
         RTT::base::PortInterface *loggerPort = logger->getPort(taskName + "." + outPort->getName());
         if(!loggerPort)
         {
-            throw std::runtime_error("Error, port created on logger could not be aquired"); 
+            throw std::runtime_error("Error, port created on logger could not be aquired");
         }
         loggerPort->disconnect();
         
@@ -246,12 +253,11 @@ bool LoggingHelper::logAllPorts(RTT::TaskContext* givenContext, const std::strin
     if(logger->isRunning())
         return true;
 
-    Bundle &bundle(Bundle::getInstance());
     int log_file_id = 0;
-    std::string log_path(bundle.getLogDirectory() + "/" + loggerName + "." + std::to_string(log_file_id) + ".log");
+    std::string log_path(log_directory + "/" + loggerName + "." + std::to_string(log_file_id) + ".log");
     while(boost::filesystem::exists(log_path))
     {
-        log_path = std::string(bundle.getLogDirectory() + "/" + loggerName + "." +  std::to_string(++log_file_id) + ".log");
+        log_path = std::string(log_directory + "/" + loggerName + "." +  std::to_string(++log_file_id) + ".log");
     }
     logger->file.set(log_path);
 

--- a/src/LoggingHelper.hpp
+++ b/src/LoggingHelper.hpp
@@ -11,7 +11,13 @@ class LoggingHelper
     const int DEFAULT_LOG_BUFFER_SIZE;
 public:
     LoggingHelper();
-    bool logAllPorts(RTT::TaskContext *context,  const std::string &loggerName, const std::vector<std::string> excludeList = std::vector<std::string>(), bool loadTypekits = true);
+    bool logAllPorts(RTT::TaskContext *context, const std::string &loggerName, const std::string& log_directory,
+                     const std::vector<std::string> excludeList = std::vector<std::string>(), bool loadTypekits = true);
+    /**
+     * This uses the local bundle instance to determine the log directory.
+     */
+    bool logAllPorts(RTT::TaskContext *context, const std::string &loggerName,
+                     const std::vector<std::string> excludeList = std::vector<std::string>(), bool loadTypekits = true);
     bool logTasks(const std::map<std::string, bool> &loggingEnabledTaskMap, bool logAll);
     bool logTasks(const std::vector<std::string> &excludeList);
     bool logTasks();

--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -69,9 +69,6 @@ void shutdownHandler(int signum, siginfo_t *info, void *data)
 
 Spawner::Spawner()
 {
-    //log dir always exists if requested from bundle
-    logDir = Bundle::getInstance().getLogDirectory();
-
     nameService = new CorbaNameService();
     nameService->connect();
 
@@ -264,6 +261,12 @@ Spawner::ProcessHandle &Spawner::spawnTask(const std::string& cmp1, const std::s
 
 Spawner::ProcessHandle& Spawner::spawnDeployment(Deployment* deployment, bool redirectOutput)
 {
+    if(redirectOutput && logDir.empty())
+    {
+        //log dir always exists if requested from bundle
+        logDir = Bundle::getInstance().getLogDirectory();
+    }
+
     ProcessHandle *handle = new ProcessHandle(deployment, redirectOutput, logDir);
     
     handles.push_back(handle);
@@ -454,4 +457,8 @@ bool Spawner::isRunning(const Deployment* instance)
     return false;
 }
 
+void Spawner::setLogDirectory(const std::string& log_folder)
+{
+    logDir = log_folder;
+}
 

--- a/src/Spawner.hpp
+++ b/src/Spawner.hpp
@@ -127,6 +127,12 @@ public:
      * Returns, if the given instance of a deployment is running.
      * */
     bool isRunning(const Deployment *instance);
+
+    /**
+     * Sets the default log directory.
+     * If no log directory is set it will be determined using bundles.
+     */
+    void setLogDirectory(const std::string& log_folder);
     
 private:
     


### PR DESCRIPTION
- Adds the possibility to call logAllPorts with a log directory as parameter
- Adds the possibility to manually set the log directory in the spawner

In both cases: If no log directory is set the bundle log directory will be used to be consistent with the current behavior. It does not alter the current default behavior.

This also solves rock-cpp/orocos_cpp#5