### PR TITLE
Add command line arguments

### DIFF
--- a/src/Deployment.cpp
+++ b/src/Deployment.cpp
@@ -192,6 +192,9 @@ bool Deployment::getExecString(std::string& cmd, std::vector< std::string >& arg
             args.push_back(p.second + ":" + p.first);
         }
     }
+
+    for(const std::string& arg : cmdLineArgs)
+        args.push_back(arg);
     
     return true;
 }
@@ -220,4 +223,9 @@ bool Deployment::hasLogger() const
 void Deployment::runWithValgrind()
 {
     withValgrind = true;
+}
+
+void Deployment::setCmdLineArgs(const std::vector<std::string> &args)
+{
+    cmdLineArgs = args;
 }

--- a/src/Deployment.hpp
+++ b/src/Deployment.hpp
@@ -27,6 +27,7 @@ private:
     std::string loggerName;
 
     bool withValgrind;
+    std::vector<std::string> cmdLineArgs;
     
 public:
     Deployment(const std::string &name);
@@ -71,6 +72,11 @@ public:
      * If called, the deployment will be started within valgrind
      * */
     void runWithValgrind();    
+
+    /**
+     * Set additional command line arguments. Default is empty
+     * */
+    void setCmdLineArgs(const std::vector<std::string> &args);
 };
 
 } //end of namespace


### PR DESCRIPTION
This allows to pass arbitrary command line arguments when starting a deployment