### PR TITLE
Changes due to RTT2.9

### DIFF
--- a/src/ConfigurationHelper.cpp
+++ b/src/ConfigurationHelper.cpp
@@ -482,6 +482,7 @@ bool ConfigurationHelper::applyConfig(RTT::TaskContext* context, const std::vect
     {
         try {
             context = RTT::corba::TaskContextProxy::Create(context->getName(), false);
+            if(!context) throw std::runtime_error("Error, could not create Proxy for " + context->getName());
         } catch(...)
         {
             throw std::runtime_error("ConfigurationHelper::applyConfig: Error, could not create Proxy for " + context->getName());

--- a/src/ConfigurationHelper.cpp
+++ b/src/ConfigurationHelper.cpp
@@ -357,6 +357,7 @@ bool applyConfOnTyplibValue(Typelib::Value &value, const ConfigValue& conf)
 bool ConfigurationHelper::applyConfToProperty(RTT::TaskContext* context, const std::string& propertyName, const libConfig::ConfigValue& value)
 {
     RTT::base::PropertyBase *property = context->getProperty(propertyName);
+    
     if(!property)
     {
         std::cout << "Error, there is no property with the name '" << propertyName << "' in the TaskContext " << context->getName() << std::endl;
@@ -440,7 +441,7 @@ bool ConfigurationHelper::applyConfig(RTT::TaskContext* context, const Configura
         if(!applyConfToProperty(context, propIt->first, *(propIt->second)))
         {
             std::cout << "ERROR configuration of " << propIt->first << " failed" << std::endl;
-            throw std::runtime_error("ERROR configuration of "  + propIt->first + " failed for context " + context->getName());
+            throw std::runtime_error("ERROR: Apply configuration of variable '"  + propIt->first + "' failed for context " + context->getName());
             return false;
         }
     }

--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -350,7 +350,7 @@ void Spawner::killAll()
             try {
                 std::cout << "Trying to stop task " << tName << std::endl;
                 RTT::corba::TaskContextProxy *proxy = RTT::corba::TaskContextProxy::Create(tName, false);
-                if(proxy->isRunning())
+                if(proxy && proxy->isRunning())
                     proxy->stop();
             }
             catch (...)

--- a/src/TypeRegistry.hpp
+++ b/src/TypeRegistry.hpp
@@ -1,4 +1,4 @@
-#define once
+#pragma once
 
 #include <string>
 #include <map>


### PR DESCRIPTION
TaskContextProxy::Create returns a nullptr now in case the task could not be found