### PR TITLE
Use registry for pkg config files instead of loading them on the fly at runtime

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ rock_library(orocos_cpp
         Deployment.cpp
         PkgConfigHelper.cpp
         PluginHelper.cpp
+        PkgConfigRegistry.cpp
     HEADERS 
         ConfigurationHelper.hpp
         TransformerHelper.hpp
@@ -24,6 +25,7 @@ rock_library(orocos_cpp
         PkgConfigHelper.hpp
         PluginHelper.hpp
         TransformationProvider.hpp
+        PkgConfigRegistry.hpp
     DEPS_PKGCONFIG
         orocos_cpp_base
         rtt_typelib-${OROCOS_TARGET}

--- a/src/Deployment.cpp
+++ b/src/Deployment.cpp
@@ -96,12 +96,6 @@ bool Deployment::loadPkgConfigFile(const std::string& deploymentName)
     PkgConfigRegistryPtr pkgreg = PkgConfigRegistry::get();
     PkgConfig pkg;
 
-    std::vector<std::string> pkgConfigFields;
-    pkgConfigFields.push_back("typekits");
-    pkgConfigFields.push_back("deployed_tasks");
-    std::vector<std::string> pkgConfigValues;
-
-    //if(!PkgConfigHelper::parsePkgConfig("/orogen-" + name + ".pc", pkgConfigFields, pkgConfigValues))
     if(!pkgreg->getDeployment(deploymentName, pkg))
         throw std::runtime_error("PkgConfig file for deployment " + deploymentName + " was not loaded." );
 
@@ -112,7 +106,7 @@ bool Deployment::loadPkgConfigFile(const std::string& deploymentName)
     }
     std::vector<std::string> typekits = PkgConfigHelper::vectorizeTokenSeparatedString(typekitsString, " ");
 
-    if(!pkg.getVariable("deployed_tasks", typekitsString)){
+    if(!pkg.getVariable("deployed_tasks", deployedTasksString)){
         throw(std::runtime_error("PkgConfig file for deployment "+deploymentName+" does not describe required typekits."));
     }
     std::vector<std::string> deployedTasks = PkgConfigHelper::vectorizeTokenSeparatedString(deployedTasksString, ",");

--- a/src/Deployment.hpp
+++ b/src/Deployment.hpp
@@ -12,7 +12,7 @@ namespace orocos_cpp
 class Deployment : public boost::noncopyable
 {
 private:
-    bool loadPkgConfigFile(const std::string &name);
+    bool loadPkgConfigFile(const std::string &deploymentName);
     bool checkExecutable(const std::string &name);
     
     std::vector<std::string> typekits;

--- a/src/PkgConfigHelper.cpp
+++ b/src/PkgConfigHelper.cpp
@@ -217,7 +217,7 @@ bool PkgConfigHelper::parsePkgConfig(const std::string& pkgConfigFileName, const
 {
     std::map<std::string,std::string> variables;
     std::map<std::string,std::string> properties;
-    parsePkgConfig(pkgConfigFileName, variables, properties);
+    parsePkgConfig(pkgConfigFileName, variables, properties, false);
 
     bool all_ok = true;
     result.resize(searchedFields.size());

--- a/src/PkgConfigHelper.cpp
+++ b/src/PkgConfigHelper.cpp
@@ -244,5 +244,18 @@ bool PkgConfigHelper::parsePkgConfig(const std::string& pkgConfigFileName, const
     return all_ok;
 }
 
+std::vector<std::string> PkgConfigHelper::vectorizeTokenSeparatedString(const std::string& data, std::string token)
+{
+    boost::char_separator<char> sep(token.c_str());
+    boost::tokenizer<boost::char_separator<char> > typekits(data, sep);
+
+    std::vector< std::string > ret;
+    for(const std::string &tk: typekits)
+    {
+        ret.push_back(tk);
+    }
+    return ret;
+}
+
 
 

--- a/src/PkgConfigHelper.cpp
+++ b/src/PkgConfigHelper.cpp
@@ -89,12 +89,14 @@ bool substitude(const std::string& line, const std::map<std::string, std::string
 //! \param line
 //! \return true if \p line is a comment. false otherwise.
 //!
-bool parseComment(const std::string& line)
+void truncateComment(std::string& line)
 {
     //Is comment if first character is '#'
-    if(line.size() < 1)
-        return false;
-    return line.at(0) == '#';
+    size_t pos = line.find('#');
+    if(pos == std::string::npos)
+        return;
+
+    line = line.substr(0, pos);
 }
 
 //!
@@ -116,6 +118,8 @@ bool parseVariable(const std::string& line, std::string& var_name, std::string& 
         assert(sm.size() == 3);
         var_name = sm[1];
         value = sm[2];
+        boost::trim(var_name);
+        boost::trim(value);
         return true;
     }
     return false;
@@ -143,6 +147,8 @@ bool parseProperty(const std::string& line, std::string& prop_name, std::string&
         assert(sm.size() == 3);
         prop_name = sm[1];
         value = sm[2];
+        boost::trim(prop_name);
+        boost::trim(value);
         return true;
     }
     return false;
@@ -170,8 +176,7 @@ bool PkgConfigHelper::parsePkgConfig(const std::string& filePathOrName, std::map
     {
         std::string curLine;
         std::getline(fileStream, curLine);
-        if(parseComment(curLine))
-            continue;
+        truncateComment(curLine);
 
         std::string name, value;
         if(parseVariable(curLine, name, value)){

--- a/src/PkgConfigHelper.cpp
+++ b/src/PkgConfigHelper.cpp
@@ -136,8 +136,8 @@ bool parseVariable(const std::string& line, std::string& var_name, std::string& 
 //!
 bool parseProperty(const std::string& line, std::string& prop_name, std::string& value)
 {
-    //Start of line, followed by a word, followed by a '=' sign, followed by a whitespace
-    std::regex e("^(\\w+):\\s(.*)");
+    //Start of line, followed by a sequence of characters, followed by a ':' sign, followed by a whitespace
+    std::regex e(R"((.+):\s(.*))");
     std::smatch sm;
     if(std::regex_match(line, sm, e)){
         assert(sm.size() == 3);

--- a/src/PkgConfigHelper.cpp
+++ b/src/PkgConfigHelper.cpp
@@ -112,7 +112,7 @@ void truncateComment(std::string& line)
 bool parseVariable(const std::string& line, std::string& var_name, std::string& value)
 {
     //Start of line, followed by a word, followed by a '=' sign, NO whitespace
-    std::regex e("^(\\w+)=(.*)");
+    std::regex e(R"(^([\w\d\.-]+)=(.*))");
     std::smatch sm;
     if(std::regex_match(line, sm, e)){
         assert(sm.size() == 3);
@@ -141,7 +141,7 @@ bool parseVariable(const std::string& line, std::string& var_name, std::string& 
 bool parseProperty(const std::string& line, std::string& prop_name, std::string& value)
 {
     //Start of line, followed by a sequence of characters, followed by a ':' sign, followed by a whitespace
-    std::regex e(R"((.+):\s(.*))");
+    std::regex e(R"(^([\w\d\.-]+):(.*))");
     std::smatch sm;
     if(std::regex_match(line, sm, e)){
         assert(sm.size() == 3);

--- a/src/PkgConfigHelper.cpp
+++ b/src/PkgConfigHelper.cpp
@@ -3,8 +3,12 @@
 #include <boost/filesystem.hpp>
 #include <boost/tokenizer.hpp>
 #include <fstream>
+#include <regex>
+#include <boost/algorithm/string.hpp>
+#include <iostream>
 
 using namespace orocos_cpp;
+
 
 bool PkgConfigHelper::solveString(std::string &input, const std::string &replace, const std::string &by)
 {
@@ -16,67 +20,194 @@ bool PkgConfigHelper::solveString(std::string &input, const std::string &replace
     return true;
 }
 
-bool PkgConfigHelper::parsePkgConfig(const std::string& pkgConfigFileName, const std::vector< std::string > &searchedFields, std::vector< std::string > &result)
+
+
+//!
+//! \brief substitudes all occurences of a varibale in \p line by it's substitudes given in \p variables
+//! \param line : The input line that can contain variables. A variable is identified by beeing enclosed by 2${}". e.g. ${varname})
+//! \param variables : A map containing <varname, value used for substitution>-tuples
+//! \param substituded : Substituded version of \p line will be stored here
+//! \return true if all varibales where successfully substituded. False if a varibale could not be resolved.
+//!
+bool substitude(const std::string& line, const std::map<std::string, std::string>& variables, std::string& substituded)
 {
-    const char *pkgConfigPath = getenv("PKG_CONFIG_PATH");
-    if(!pkgConfigPath)
-    {
-        throw std::runtime_error("Internal Error, no pkgConfig path found.");
-    }
-    
-    std::string pkgConfigPathS = pkgConfigPath;
-    
-    boost::char_separator<char> sep(":");
-    boost::tokenizer<boost::char_separator<char> > paths(pkgConfigPathS, sep);
-    
-    std::string searchedPath;
-    
-    for(const std::string &path: paths)
-    {
-        std::string candidate = path + "/" + pkgConfigFileName;
-        if(boost::filesystem::exists(candidate))
-        {
-            searchedPath = candidate;
-            break;
+    std::regex e{R"(.*\$\{(\w*)\}.*)"};
+    std::smatch sm;
+    std::cout <<"====" <<std::endl;
+    std::cout << line <<std::endl;
+    std::string new_line = line;
+    bool ok = true;
+    while(std::regex_match(new_line, sm, e)){
+        std::string varname = sm[1];
+        std::string varstr = "${"+varname+"}";
+        try{
+            std::string val = variables.at(varname);
+            size_t pos = new_line.find(varstr);
+            new_line.replace(pos, varstr.size(), val);
+        }catch(std::out_of_range ex){
+            std::clog << "Could not substitude varibale " << varname << std::endl;
+            ok=false;
         }
     }
+    substituded = new_line;
+    std::cout << substituded <<std::endl;
+    std::cout <<"...." <<std::endl;
+    return ok;
+}
 
-    if(searchedPath.empty())
+//!
+//! \brief Identifies if the given \p line is a PKGConfig comment
+//! \param line
+//! \return true if \p line is a comment. false otherwise.
+//!
+bool parseComment(const std::string& line)
+{
+    //Is comment if first character is '#'
+    if(line.size() < 1)
+        return false;
+    return line.at(0) == '#';
+}
+
+//!
+//! \brief Identifies if the given \p line is a variable assignment
+//! Varibales in PKGConfig can have arbitrary names. They are assigned by "varname=value".
+//! Example:
+//!     prefix=/my/prefix
+//!     exec_prefix=${prefix}
+//!     libdir=${prefix}/lib/orocos/types
+//! \param line
+//! \return true if \p line is a varibale assignment. false otherwise.
+//!
+bool parseVariable(const std::string& line, std::string& var_name, std::string& value)
+{
+    //Start of line, followed by a word, followed by a '=' sign, NO whitespace
+    std::regex e("^(\\w+)=(.*)");
+    std::smatch sm;
+    if(std::regex_match(line, sm, e)){
+        assert(sm.size() == 3);
+        var_name = sm[1];
+        value = sm[2];
+        return true;
+    }
+    return false;
+}
+
+//!
+//! \brief Identifies if the given \p line is a property assignment
+//! //! In PKGConfig there exists a defined set of properties to describe a software module for compiling and linking. They are assigned by "propname: value".
+//! Example:
+//!    Name: testTypekit
+//!    Version: 0.0
+//!    Requires: test
+//!    Description: test types support for the Orocos type system
+//!    Libs: -L${libdir} -ltest-typekit-gnulinux
+//!    Cflags: -I${includedir} -I${includedir}/test/types "-DOROCOS_TARGET=gnulinux"
+//! \param line
+//! \return true if \p line is a comment. false otherwise.
+//!
+bool parseProperty(const std::string& line, std::string& prop_name, std::string& value)
+{
+    //Start of line, followed by a word, followed by a '=' sign, followed by a whitespace
+    std::regex e("^(\\w+):\\s(.*)");
+    std::smatch sm;
+    if(std::regex_match(line, sm, e)){
+        assert(sm.size() == 3);
+        prop_name = sm[1];
+        value = sm[2];
+        return true;
+    }
+    return false;
+}
+
+bool PkgConfigHelper::parsePkgConfig(const std::string& pkgConfigFileName, std::map<std::string,std::string>& variables, std::map<std::string,std::string>& properties)
+{
+    //Resolve full filepath for filename given via pkgConfigFileName
+    std::vector<std::string> paths = get_search_paths_from_env_var();
+    std::string filepath = find_file(pkgConfigFileName, paths);
+
+    if(filepath.empty())
     {
         throw std::runtime_error("Error, could not find pkg-config file " + pkgConfigFileName + " in the PKG_CONFIG_PATH");
     }
-    
-    std::vector<bool> found;
-    result.resize(searchedFields.size());
-    found.resize(searchedFields.size(), false);
-    
-    std::ifstream fileStream(searchedPath);
-    
+
+    std::ifstream fileStream(filepath);
+    bool all_ok=true;
     while(!fileStream.eof())
     {
         std::string curLine;
         std::getline(fileStream, curLine);
-        for(size_t i = 0; i < searchedFields.size(); i++)
-        {
-            const std::string searched(searchedFields[i] + "=");
-            if(curLine.substr(0, searched.size()) == searched)
-            {
-                result[i] = curLine.substr(searched.size(), curLine.size());
-                found[i] = true;
-                
-                //check if we found all search values
-                bool doReturn = true;
-                for(bool f: found)
-                {
-                    doReturn &= f;
-                }
-                if(doReturn)
-                    return true;
-            }
-        }        
+        if(parseComment(curLine))
+            continue;
+
+        std::string name, value;
+        if(parseVariable(curLine, name, value)){
+            variables[name] = value;
+            continue;
+        }
+        if(parseProperty(curLine, name, value)){
+            properties[name] = value;
+            continue;
+        }
+
+        //Not a comment, property or variable.. check if empty (only whitespaces and print warning otherwise)
+        std::string curLine2 = curLine;
+        std::string::iterator end_pos = std::remove(curLine2.begin(), curLine2.end(), ' '); //Removes all whitespaces
+        curLine2.erase(end_pos, curLine2.end());
+
+        //Deletes all whitespaces
+        if(!curLine2.empty()){
+            std::clog << "Warning: Could not parse line " << curLine << " from PkgConfig-file " << filepath << std::endl;
+            all_ok = false;
+        }
     }
-    
-    return false;
+
+    //Substitude field values with values from variables
+    for(std::pair<const std::string, std::string>& var : variables){
+        bool st = substitude(var.second, variables, var.second);
+        if(!st){
+            std::clog << "Could not substitude value '" << var.second << "' of variable " << var.first << " from PkgConfig-file " << filepath << std::endl;
+            all_ok = false;
+        }
+    }
+    for(std::pair<const std::string, std::string>& prop : properties){
+        bool st = substitude(prop.second, variables, prop.second);
+        if(!st){
+            std::clog << "Could not substitude value " << prop.second << "' of property "<< prop.first << " from PkgConfig-file " << filepath << std::endl;
+            all_ok = false;
+        }
+    }
+    return all_ok;
+}
+
+bool PkgConfigHelper::parsePkgConfig(const std::string& pkgConfigFileName, const std::vector< std::string > &searchedFields, std::vector< std::string > &result, bool is_property)
+{
+    std::map<std::string,std::string> variables;
+    std::map<std::string,std::string> properties;
+    parsePkgConfig(pkgConfigFileName, variables, properties);
+
+    bool all_ok = true;
+    result.resize(searchedFields.size());
+    for(size_t i=0; i<searchedFields.size(); i++){
+        const std::string& fname = searchedFields[i];
+        std::map<std::string,std::string>::iterator it;
+        std::map<std::string,std::string>::iterator not_found;
+
+        if(is_property){
+            it = properties.find(fname);
+            not_found = properties.end();
+        }
+        else{
+            it = variables.find(fname);
+            not_found = variables.end();
+        }
+        if(it == not_found)
+            all_ok &= false;
+        else{
+            all_ok &= true;
+            result[i] = it->second;
+        }
+    }
+    return all_ok;
 }
 
 

--- a/src/PkgConfigHelper.hpp
+++ b/src/PkgConfigHelper.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 namespace orocos_cpp
 {
@@ -10,20 +11,28 @@ namespace orocos_cpp
 class PkgConfigHelper
 {
 public:
-    /**
+    /** deprecated
      * Helper function that parses a pkg-Config file. 
      * Will open the file of the given name, and search 
      * for the fields given in searchedFields. The content
      * of the field will be returned in the result vector
      * in the same order as searchedFields. 
      * */
-    static bool parsePkgConfig(const std::string &pkgConfigFileName, const std::vector<std::string> &searchedFields, std::vector<std::string> &result);
+    __attribute__((__deprecated__))
+    static bool parsePkgConfig(const std::string &pkgConfigFileName, const std::vector<std::string> &searchedFields, std::vector<std::string> &result, bool is_property=false);
+    /**
+     * @brief parsePkgConfig
+     * @param pkgConfigFileName : filename of pkgconfig file to parse. The file will be search for in all folders specified in PKG_CONFIG_PATH environment variable
+     * @param variables : All variables specified in \p pkgConfigFileName as <varname, value>-tuples will be stored here
+     * @param properties : All properties specified in \p pkgConfigFileName as <varname, value>-tuples will be stored here
+     * @return false if any error occured
+     */
+    static bool parsePkgConfig(const std::string& pkgConfigFileName, std::map<std::string,std::string>& variables, std::map<std::string, std::string> &properties);
 
     /**
     * Helper function, to replace a given string by a given string in an input string.
     * */
     static bool solveString(std::string &input, const std::string &replace, const std::string &by);
 };
-
 }//end of namespace
 #endif // PKGCONFIGHELPER_H

--- a/src/PkgConfigHelper.hpp
+++ b/src/PkgConfigHelper.hpp
@@ -35,6 +35,14 @@ public:
     * Helper function, to replace a given string by a given string in an input string.
     * */
     static bool solveString(std::string &input, const std::string &replace, const std::string &by);
+
+    /**
+     * @brief Vectorize a string into separated elements at the occurance of a specific token
+     * @param data : The string to process. e.g. [/hello/world:/tolle/sache]
+     * @param token : Character at which the string should be splitted. e.g. ':'
+     * @return Vector of individual elements. With the input given about would result in ["/hello/world", "/tolle/sache"]
+     */
+    static std::vector<std::string> vectorizeTokenSeparatedString(const std::string& data, std::string token);
 };
 }//end of namespace
 #endif // PKGCONFIGHELPER_H

--- a/src/PkgConfigHelper.hpp
+++ b/src/PkgConfigHelper.hpp
@@ -11,6 +11,8 @@ namespace orocos_cpp
 class PkgConfigHelper
 {
 public:
+    static std::vector<std::string> getSearchPathsFromEnvVar();
+
     /** deprecated
      * Helper function that parses a pkg-Config file. 
      * Will open the file of the given name, and search 
@@ -27,7 +29,7 @@ public:
      * @param properties : All properties specified in \p pkgConfigFileName as <varname, value>-tuples will be stored here
      * @return false if any error occured
      */
-    static bool parsePkgConfig(const std::string& pkgConfigFileName, std::map<std::string,std::string>& variables, std::map<std::string, std::string> &properties);
+    static bool parsePkgConfig(const std::string& filePathOrName, std::map<std::string,std::string>& variables, std::map<std::string, std::string> &properties, bool isFilePath = true);
 
     /**
     * Helper function, to replace a given string by a given string in an input string.

--- a/src/PkgConfigRegistry.cpp
+++ b/src/PkgConfigRegistry.cpp
@@ -1,0 +1,344 @@
+#include "PkgConfigRegistry.hpp"
+#include "PkgConfigHelper.hpp"
+#include <regex>
+#include <boost/filesystem.hpp>
+#include <base-logging/Logging.hpp>
+
+orocos_cpp::PkgConfigRegistryPtr __pkgcfgreg = nullptr;
+
+template<typename T>
+void extract_keys(const std::map<std::string,T>& m, std::vector<std::string>& res){
+    for(const auto& kv : m) {
+        res.push_back(kv.first);
+    }
+}
+
+orocos_cpp::PkgConfig::PkgConfig() :
+    sourceFile("")
+{
+
+}
+
+bool orocos_cpp::PkgConfig::getVariable(const std::string &fieldName, std::string& value)
+{
+    std::map<std::string, std::string>::iterator it = variables.find(fieldName);
+    if(it == variables.end())
+        return false;
+
+    value = it->second;
+    return true;
+}
+
+bool orocos_cpp::PkgConfig::getProperty(const std::string &fieldName, std::string& value)
+{
+    std::map<std::string, std::string>::iterator it = properties.find(fieldName);
+    if(it == properties.end())
+        return false;
+
+    value = it->second;
+    return true;
+}
+
+bool orocos_cpp::PkgConfig::load(const std::string &filepath)
+{
+    bool st = PkgConfigHelper::parsePkgConfig(filepath, variables, properties);
+    bool got_name = getProperty("Name", name);
+    sourceFile = filepath;
+    return st;
+}
+
+bool orocos_cpp::PkgConfig::isLoaded()
+{
+    return !this->sourceFile.empty();
+}
+
+
+bool orocos_cpp::PkgConfigRegistry::initialize()
+{
+    LOG_INFO_S << "Scanning for PKGConfig files for orogen project, typekits, transports, tasks and deployments";
+    std::vector<std::string> searchPaths = PkgConfigHelper::getSearchPathsFromEnvVar();
+    scan(searchPaths);
+    LOG_INFO_S << "Scanning for PKG config files done.";
+    return true;
+}
+
+bool orocos_cpp::PkgConfigRegistry::getDeployment(const std::string &name, orocos_cpp::PkgConfig &pkg)
+{
+    std::map<std::string, PkgConfig>::iterator it = deployments.find(name);
+    if(it == deployments.end()){
+        return false;
+    }
+    pkg = it->second;
+    return true;
+}
+
+bool orocos_cpp::PkgConfigRegistry::getTypekit(const std::string &name, orocos_cpp::TypekitPkgConfig &pkg)
+{
+    std::map<std::string, TypekitPkgConfig>::iterator it = typekits.find(name);
+    if(it == typekits.end()){
+        return false;
+    }
+    pkg = it->second;
+    return true;
+}
+
+bool orocos_cpp::PkgConfigRegistry::getOrogen(const std::string &name, orocos_cpp::OrogenPkgConfig &pkg)
+{
+    std::map<std::string, OrogenPkgConfig>::iterator it = orogen.find(name);
+    if(it == orogen.end()){
+        return false;
+    }
+    pkg = it->second;
+    return true;
+}
+
+std::vector<std::string> orocos_cpp::PkgConfigRegistry::getRegisteredDeploymentNames()
+{
+    std::vector<std::string> ret;
+    extract_keys(deployments, ret);
+    return ret;
+}
+
+std::vector<std::string> orocos_cpp::PkgConfigRegistry::getRegisteredTypekitNames()
+{
+    std::vector<std::string> ret;
+    extract_keys(typekits, ret);
+    return ret;
+}
+
+std::vector<std::string> orocos_cpp::PkgConfigRegistry::getRegisteredOrogenNames()
+{
+    std::vector<std::string> ret;
+    extract_keys(orogen, ret);
+    return ret;
+}
+
+orocos_cpp::PkgConfigRegistryPtr orocos_cpp::PkgConfigRegistry::get()
+{
+    if(!__pkgcfgreg){
+        __pkgcfgreg = PkgConfigRegistryPtr(new PkgConfigRegistry());
+        __pkgcfgreg->initialize();
+    }
+    return __pkgcfgreg;
+}
+
+bool orocos_cpp::PkgConfigRegistry::isTransportPkg(const std::string &filename, std::string &typekitName, std::string &transportName, std::string& arch)
+{
+    std::regex r(R"(([\w\d]+)-transport-([\w]+)-([\w]+).pc)");
+    std::smatch match;
+    if(std::regex_match(filename, match, r)){
+        LOG_DEBUG_S << filename << " is Transport:";
+        typekitName = match[1];
+        transportName = match[2];
+        arch = match[3];
+        LOG_DEBUG_S << "  typekit: "<<typekitName<<"\n  trasnport: "<<transportName<<"\n  arch: "<<arch;
+        return true;
+    }
+    return false;
+}
+
+bool orocos_cpp::PkgConfigRegistry::isOrogenTasksPkg(const std::string &filename, std::string &orogenProjectName, std::string& arch)
+{
+    std::regex r(R"(([\w\d]+)-tasks-([\w\d]+).pc)");
+    std::smatch match;
+    if(std::regex_match(filename, match, r)){
+        LOG_DEBUG_S << filename << " is OrogenTasks:";
+        orogenProjectName = match[1];
+        arch = match[2];
+        LOG_DEBUG_S << "  orogen: "<<orogenProjectName<<"\n  arch: "<<arch;
+        return true;
+    }
+    return false;
+}
+
+bool orocos_cpp::PkgConfigRegistry::isOrogenProjectPkg(const std::string &filename, std::string &orogenProjectName)
+{
+    std::regex r(R"(orogen-project-([\w\d]+).pc)");
+    std::smatch match;
+    if(std::regex_match(filename, match, r)){
+        LOG_DEBUG_S << filename << " is OrogenProject:";
+        orogenProjectName = match[1];
+        LOG_DEBUG_S << "  orogen: "<<orogenProjectName;
+        return true;
+    }
+    return false;
+}
+
+bool orocos_cpp::PkgConfigRegistry::isTypekitPkg(const std::string &filename, std::string &typekitName, std::string& arch)
+{
+    std::regex r(R"(([\w\d]+)-typekit-([\w\d]+).pc)");
+    std::smatch match;
+    if(std::regex_match(filename, match, r)){
+        LOG_DEBUG_S << filename << " is Typekit:";
+        typekitName = match[1];
+        arch = match[2];
+        LOG_DEBUG_S << "  typekit: "<<typekitName;
+        LOG_DEBUG_S << "  arch: "<<arch;
+        return true;
+    }
+    return false;
+}
+
+bool orocos_cpp::PkgConfigRegistry::isProxiesPkg(const std::string &filename, std::string &orogenProjectName)
+{
+    std::regex r(R"(([\w\d]+)-proxies.pc)");
+    std::smatch match;
+    if(std::regex_match(filename, match, r)){
+        LOG_DEBUG_S << filename << " is Proxies:";
+        orogenProjectName = match[1];
+        LOG_DEBUG_S << "  orogen: "<<orogenProjectName;
+        return true;
+    }
+    return false;
+}
+
+bool orocos_cpp::PkgConfigRegistry::isDeploymentPkg(const std::string &filename, std::string &deploymentName)
+{
+    std::regex r(R"(orogen-([\w\d]+).pc)");
+    std::smatch match;
+    if(std::regex_match(filename, match, r)){
+        LOG_DEBUG_S << filename << " is Deployment:";
+        deploymentName = match[1];
+        LOG_DEBUG_S << "  depoyment: "<<deploymentName;
+        return true;
+    }
+    return false;
+}
+
+bool orocos_cpp::PkgConfigRegistry::addFile(const std::string &filepath)
+{
+    std::string typekitName, orogenProjectName, deploymentName, arch, transportName;
+    PkgConfig pkg;
+    boost::filesystem::path p(filepath);
+    std::string filename = p.filename().string();
+
+    //Is Deployment?
+    if(isDeploymentPkg(filename, deploymentName)){
+        bool st = pkg.load(filepath);
+        std::map<std::string, PkgConfig>::iterator it = deployments.find(deploymentName);
+        if(it != deployments.end()){
+            LOG_WARN_S << "Ignoring PKGConfig file "<<filepath<<", because it describes a deployment with name " << deploymentName << ", but there was already a PKGConfig file for the same deployment added with the file " << it->second.sourceFile << ".";
+            return false;
+        }
+        deployments[deploymentName] = pkg;
+        return st;
+    }
+
+    //Is Proxy?
+    else if(isProxiesPkg(filename, orogenProjectName)){
+        bool st = pkg.load(filepath);
+        std::map<std::string, OrogenPkgConfig>::iterator it = orogen.find(orogenProjectName);
+
+        if(it == orogen.end()){
+            orogen[orogenProjectName] = OrogenPkgConfig();
+            it = orogen.find(orogenProjectName);
+        }
+
+        if(it->second.proxies.isLoaded()){
+            LOG_WARN_S << "Ignoring PKGConfig file "<<filepath<<", because it describes task proxies for the orogen project " << orogenProjectName << ", but they were already be imported from the PKGConfig file " << it->second.proxies.sourceFile << ".";
+            return false;
+        }
+        it->second.proxies = pkg;
+        return st;
+    }
+
+    //Is OrogenProject
+    else if(isOrogenProjectPkg(filename, orogenProjectName)){
+        bool st = pkg.load(filepath);
+        std::map<std::string, OrogenPkgConfig>::iterator it = orogen.find(orogenProjectName);
+
+        if(it == orogen.end()){
+            orogen[orogenProjectName] = OrogenPkgConfig();
+            it = orogen.find(orogenProjectName);
+        }
+
+        if(it->second.project.isLoaded()){
+            LOG_WARN_S << "Ignoring PKGConfig file "<<filepath<<", because it describes the orogen project " << orogenProjectName << ", but it was already described by the PKGConfig file " << it->second.project.sourceFile << ".";
+            return false;
+        }
+        it->second.project = pkg;
+        return st;
+    }
+
+    //Is OrogenTasks
+    else if(isOrogenTasksPkg(filename, orogenProjectName, arch)){
+        bool st = pkg.load(filepath);
+        std::map<std::string, OrogenPkgConfig>::iterator it = orogen.find(orogenProjectName);
+
+        if(it == orogen.end()){
+            orogen[orogenProjectName] = OrogenPkgConfig();
+            it = orogen.find(orogenProjectName);
+        }
+
+        if(it->second.tasks.isLoaded()){
+            LOG_WARN_S << "Ignoring PKGConfig file "<<filepath<<", because it describes the tasks for the orogen project " << orogenProjectName << ", but the tasks were already described by the PKGConfig file " << it->second.tasks.sourceFile << ".";
+            return false;
+        }
+        it->second.tasks = pkg;
+        return st;
+    }
+
+    //Is Transports
+    else if(isTransportPkg(filename, typekitName, transportName, arch)){
+        bool st = pkg.load(filepath);
+        std::map<std::string, TypekitPkgConfig>::iterator it = typekits.find(typekitName);
+
+        if(it == typekits.end()){
+            typekits[typekitName] = TypekitPkgConfig();
+            it = typekits.find(typekitName);
+        }
+
+        std::map<std::string, PkgConfig>::iterator transportit = it->second.transports.find(transportName);
+        if(transportit != it->second.transports.end()){
+            LOG_WARN_S << "Ignoring PKGConfig file "<<filepath<<", because it describes the transport " << transportName << " for typekit " << typekitName << ", but the transport was already described by the PKGConfig file " << transportit->second.sourceFile << ".";
+            return false;
+        }
+        it->second.transports[transportName] = pkg;
+        return st;
+    }
+
+    //Is Typekit
+    else if(isTypekitPkg(filename, typekitName, arch)){
+        bool st = pkg.load(filepath);
+        std::map<std::string, TypekitPkgConfig>::iterator it = typekits.find(typekitName);
+        if(it == typekits.end()){
+            typekits[typekitName] = TypekitPkgConfig();
+            it = typekits.find(typekitName);
+        }
+
+        if(it->second.typekit.isLoaded()){
+            LOG_WARN_S << "Ignoring PKGConfig file "<<filepath<<", because it describes the typekit " << typekitName << ", but the typekit was already described by the PKGConfig file " << it->second.typekit.sourceFile << ".";
+            return false;
+        }
+        it->second.typekit = pkg;
+        return st;
+    }
+    else{
+        //Do nothing.. we don't load pkgconfig files for arbitrary libraries, since we'll not need them.
+        return false;
+    }
+}
+
+void orocos_cpp::PkgConfigRegistry::scan(const std::vector<std::string> &searchPaths)
+{
+    namespace fs = boost::filesystem;
+
+    for(const std::string& path : searchPaths){
+        if(!fs::is_directory(path)){
+            LOG_WARN_S << "Skipping directory " << path << " since it is not a valid directory";
+            continue;
+        }
+        for (fs::directory_iterator itr(path); itr!=fs::directory_iterator(); ++itr)
+        {
+            if( fs::is_regular_file(*itr) ){
+                bool st = addFile(itr->path().string());
+                if(st){
+                    LOG_INFO_S << "Loaded PkgConfig file " << itr->path().string() << "\t" << "[OK]";
+                }else{
+                    LOG_INFO_S << "Loaded PkgConfig file " << itr->path().string() << "\t" << "[IGNORED]";
+                }
+            }
+        }
+    }
+}
+

--- a/src/PkgConfigRegistry.cpp
+++ b/src/PkgConfigRegistry.cpp
@@ -4,7 +4,7 @@
 #include <boost/filesystem.hpp>
 #include <base-logging/Logging.hpp>
 
-orocos_cpp::PkgConfigRegistryPtr __pkgcfgreg = nullptr;
+orocos_cpp::PkgConfigRegistryPtr orocos_cpp::__pkgcfgreg(nullptr);
 
 template<typename T>
 void extract_keys(const std::map<std::string,T>& m, std::vector<std::string>& res){

--- a/src/PkgConfigRegistry.hpp
+++ b/src/PkgConfigRegistry.hpp
@@ -1,0 +1,106 @@
+#include <map>
+#include <vector>
+#include <memory>
+
+namespace orocos_cpp{
+class PkgConfig
+{
+public:
+    PkgConfig();
+    /*!
+     * \brief Get value of a variable defined within PKGConfig
+     * Varibales in PKGConfig files can have arbitrary names. They are assigned by "varname=value".
+     * Example:
+     *   prefix=/my/prefix
+     *   exec_prefix=${prefix}
+     *   libdir=${prefix}/lib/orocos/types
+     * \param variableName : name of the variable
+     * \param value : assigned value of the variable \p variableName will be be retured here
+     * \return true of value was successfully read. False if variable was not defined and thus value could net be determined.
+     */
+    bool getVariable(const std::string& variableName, std::string& value);
+
+    /*!
+     * \brief Get value of a property defined within PKGConfig
+     * In PKGConfig files there exists a defined set of properties to describe a software module for compiling and linking. They are assigned by "propname: value".
+     *   Example:
+     *   Name: testTypekit
+     *   Version: 0.0
+     *   Requires: test
+     *   Description: test types support for the Orocos type system
+     *   Libs: -L${libdir} -ltest-typekit-gnulinux
+     *   Cflags: -I${includedir} -I${includedir}/test/types "-DOROCOS_TARGET=gnulinux"
+     * \param propertyName : name of the property
+     * \param value : assigned value of the property \p propertyName will be be retured here
+     * \return true of value was successfully read. False if varibale was not defined and thus value could net be determined.
+     */
+    bool getProperty(const std::string& propertyName, std::string& value);
+
+    /*!
+     * \brief load and parse a PKGConfig file
+     * The file will be searched in paths specified in the PKG_CONFIG_PATH envirionment variable
+     * \param filename
+     */
+    bool load(const std::string& filename);
+    std::string name;
+    std::string sourceFile;
+
+    /*!
+     * \brief Checks wether PKGConfig file has been loaded
+     * \return
+     */
+    bool isLoaded();
+
+protected:
+    std::map<std::string, std::string> variables;
+    std::map<std::string, std::string> properties;
+};
+
+class TypekitPkgConfig{
+public:
+    PkgConfig typekit;
+    //! Maps transport name (e.g. 'mqueue') to the corresponding PKGConfig
+    std::map<std::string, PkgConfig> transports;
+};
+
+class OrogenPkgConfig{
+public:
+    PkgConfig tasks;
+    PkgConfig project;
+    PkgConfig proxies;
+};
+
+class PkgConfigRegistry;
+typedef std::shared_ptr<PkgConfigRegistry> PkgConfigRegistryPtr;
+PkgConfigRegistryPtr __pkgcfgreg;
+
+class PkgConfigRegistry
+{
+public:
+    bool initialize();
+    bool getDeployment(const std::string& name, PkgConfig& pkg);
+    bool getTypekit(const std::string& name, TypekitPkgConfig &pkg);
+    bool getOrogen(const std::string& name, OrogenPkgConfig& pkg);
+    std::vector<std::string> getRegisteredDeploymentNames();
+    std::vector<std::string> getRegisteredTypekitNames();
+    std::vector<std::string> getRegisteredOrogenNames();
+    static PkgConfigRegistryPtr get();
+
+protected:
+    //! To what kind of package a Pkgconfig file is related to is determined by its filename (NOT path, must be a file name!)
+    bool isTransportPkg(const std::string& filename, std::string& typekitName, std::string& transportName, std::string &arch);
+    bool isOrogenTasksPkg(const std::string& filename, std::string& orogenProjectName, std::string &arch);
+    bool isOrogenProjectPkg(const std::string& filename, std::string& orogenProjectName);
+    bool isTypekitPkg(const std::string& filename, std::string& typekitName, std::string &arch);
+    bool isProxiesPkg(const std::string& filename, std::string& orogenProjectName);
+    bool isDeploymentPkg(const std::string& filename, std::string& deploymentName);
+
+    bool addFile(const std::string& filepath);
+    void scan(const std::vector<std::string>& searchPaths);
+
+    std::map<std::string, PkgConfig> deployments;
+    std::map<std::string, OrogenPkgConfig> orogen;
+    std::map<std::string, TypekitPkgConfig> typekits;
+};
+
+}

--- a/src/PkgConfigRegistry.hpp
+++ b/src/PkgConfigRegistry.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <map>
 #include <vector>
 #include <memory>
@@ -72,7 +73,7 @@ public:
 
 class PkgConfigRegistry;
 typedef std::shared_ptr<PkgConfigRegistry> PkgConfigRegistryPtr;
-PkgConfigRegistryPtr __pkgcfgreg;
+extern PkgConfigRegistryPtr __pkgcfgreg;
 
 class PkgConfigRegistry
 {
@@ -100,9 +101,13 @@ protected:
     bool addFile(const std::string& filepath);
     void scan(const std::vector<std::string>& searchPaths);
 
+    //Containers to store PkgConfig files for different categories of libraries used
+    //in Rock
     std::map<std::string, PkgConfig> deployments;
     std::map<std::string, OrogenPkgConfig> orogen;
     std::map<std::string, TypekitPkgConfig> typekits;
+    //orocos-rtt library does not fit the other categories above
+    PkgConfig orocosRTTPkg;
 };
 
 }

--- a/src/PkgConfigRegistry.hpp
+++ b/src/PkgConfigRegistry.hpp
@@ -81,6 +81,7 @@ public:
     bool getDeployment(const std::string& name, PkgConfig& pkg);
     bool getTypekit(const std::string& name, TypekitPkgConfig &pkg);
     bool getOrogen(const std::string& name, OrogenPkgConfig& pkg);
+    bool getOrocosRTT(PkgConfig& pkg);
     std::vector<std::string> getRegisteredDeploymentNames();
     std::vector<std::string> getRegisteredTypekitNames();
     std::vector<std::string> getRegisteredOrogenNames();
@@ -94,6 +95,7 @@ protected:
     bool isTypekitPkg(const std::string& filename, std::string& typekitName, std::string &arch);
     bool isProxiesPkg(const std::string& filename, std::string& orogenProjectName);
     bool isDeploymentPkg(const std::string& filename, std::string& deploymentName);
+    bool isOrocosRTTPkg(const std::string &filename, std::string &arch);
 
     bool addFile(const std::string& filepath);
     void scan(const std::vector<std::string>& searchPaths);

--- a/src/PluginHelper.cpp
+++ b/src/PluginHelper.cpp
@@ -85,7 +85,7 @@ bool PluginHelper::loadTypekitAndTransports(const std::string& typekitName)
             throw std::runtime_error("PkgConfig for OROCOS RTT package was not loaded");
         }
         std::string libdir;
-        pkg.getProperty("libdir", libdir);
+        pkg.getVariable("libdir", libdir);
         if(!loader.loadTypekits(libdir + "/orocos/gnulinux/"))
             throw std::runtime_error("Error, failed to load rtt basis typekits");
 

--- a/src/PluginHelper.hpp
+++ b/src/PluginHelper.hpp
@@ -19,7 +19,7 @@ public:
      * This function loads the typekits and transports of the given
      * component.
      * */
-    static bool loadTypekitAndTransports(const std::string &componentName);
+    static bool loadTypekitAndTransports(const std::string &typekitName);
 
     /**
      * This method loads all typkits required for a task model.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,11 @@
 rock_testsuite(test_typeregistry test_typeregistry.cpp
     DEPS orocos_cpp
-    DEPS_PKGCONFIG base-types)
+    DEPS_PKGCONFIG base-types orocos-rtt-${OROCOS_TARGET})
+
+rock_testsuite(test_pkgconfig_helper test_pkgconfig_helper.cpp
+    DEPS orocos_cpp
+    DEPS_PKGCONFIG base-types orocos-rtt-${OROCOS_TARGET})
+
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/testfile.tlb
             ${CMAKE_CURRENT_BINARY_DIR}/testfile.tlb COPYONLY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,9 @@ rock_testsuite(test_pkgconfig_helper test_pkgconfig_helper.cpp
     DEPS orocos_cpp
     DEPS_PKGCONFIG base-types orocos-rtt-${OROCOS_TARGET})
 
+rock_testsuite(test_pkgconfig_registry test_pkgconfig_registry.cpp
+    DEPS orocos_cpp
+    DEPS_PKGCONFIG base-types orocos-rtt-${OROCOS_TARGET})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/testfile.tlb
             ${CMAKE_CURRENT_BINARY_DIR}/testfile.tlb COPYONLY)

--- a/test/test_pkgconfig/aggregator-transport-corba-gnulinux.pc
+++ b/test/test_pkgconfig/aggregator-transport-corba-gnulinux.pc
@@ -1,0 +1,18 @@
+# Generated from orogen/lib/orogen/templates/typekit/corba/transport-corba.pc
+
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=${prefix}
+libdir=${prefix}/lib/orocos/types
+includedir=${prefix}/include/orocos
+
+project_name=aggregator
+deffile=${prefix}/share/orogen/aggregator.orogen
+type_registry=${prefix}/share/orogen/aggregator.tlb
+corba_idl_requires=base,std
+
+Name: aggregatorCorbaTransport
+Version: 0.0
+Description: aggregator types support for the Orocos type system
+Libs: -L${libdir} -laggregator-transport-corba-gnulinux
+Cflags: -I${includedir}
+

--- a/test/test_pkgconfig/aggregator-transport-mqueue-gnulinux.pc
+++ b/test/test_pkgconfig/aggregator-transport-mqueue-gnulinux.pc
@@ -1,0 +1,17 @@
+# Generated from orogen/lib/orogen/templates/typekit/mqueue/transport-mqueue.pc
+
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=${prefix}
+libdir=${prefix}/lib/orocos/types
+includedir=${prefix}/include/orocos
+
+project_name=aggregator
+deffile=${prefix}/share/orogen/aggregator.orogen
+type_registry=${prefix}/share/orogen/aggregator.tlb
+
+Name: aggregatorMQueueTransport
+Version: 0.0
+Description: aggregator types support for the Orocos type system
+Libs: -L${libdir} -laggregator-transport-mqueue-gnulinux
+Cflags: -I${includedir}
+

--- a/test/test_pkgconfig/aggregator-transport-typelib-gnulinux.pc
+++ b/test/test_pkgconfig/aggregator-transport-typelib-gnulinux.pc
@@ -1,0 +1,18 @@
+# Generated from orogen/lib/orogen/templates/typekit/typelib/transport-typelib.pc 
+
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=${prefix}
+libdir=${prefix}/lib/orocos/types
+includedir=${prefix}/include/orocos
+
+project_name=aggregator
+deffile=${prefix}/share/orogen/aggregator.orogen
+type_registry=/media/wirkus/Data/development/rock-runtime/install/share/orogen/aggregator.tlb
+
+Name: aggregatorTypelibTransport
+Version: 0.0
+Requires: rtt_typelib-gnulinux 
+Description: aggregator types support for the Orocos type system
+Libs: -L${libdir} -laggregator-transport-typelib-gnulinux
+Cflags: -I${includedir}
+

--- a/test/test_pkgconfig/aggregator-typekit-gnulinux.pc
+++ b/test/test_pkgconfig/aggregator-typekit-gnulinux.pc
@@ -1,0 +1,18 @@
+# Generated from orogen/lib/orogen/templates/typekit/typekit.pc
+
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=${prefix}
+libdir=${prefix}/lib/orocos/types
+includedir=${prefix}/include/orocos
+
+project_name=aggregator
+deffile=${prefix}/share/orogen/aggregator.orogen
+type_registry=${prefix}/share/orogen/aggregator.tlb
+
+Name: aggregatorTypekit
+Version: 0.0
+Requires: aggregator
+Description: aggregator types support for the Orocos type system
+Libs: -L${libdir} -laggregator-typekit-gnulinux
+Cflags: -I${includedir} -I${includedir}/aggregator/types -I/media/wirkus/Data/development/rock-runtime/install/include "-DOROCOS_TARGET=gnulinux" "-I/media/wirkus/Data/development/rock-runtime/install/include" "-I/usr/include/eigen3" "-I/media/wirkus/Data/development/rock-runtime/install/include/orocos" "-I/media/wirkus/Data/development/rock-runtime/install/include/orocos/base/types" "-I/media/wirkus/Data/development/rock-runtime/install/include/orocos/std/types"
+

--- a/test/test_pkgconfig/aggregator.pc
+++ b/test/test_pkgconfig/aggregator.pc
@@ -1,0 +1,12 @@
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=/media/wirkus/Data/development/rock-runtime/install
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: aggregator
+Description: 
+Version: 0.1
+Requires:  base-types base-lib
+Libs: -L${libdir} -laggregator
+Cflags: -I${includedir}
+

--- a/test/test_pkgconfig/backward.pc
+++ b/test/test_pkgconfig/backward.pc
@@ -1,0 +1,12 @@
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=/media/wirkus/Data/development/rock-runtime/install
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: backward
+Description: Backward is a beautiful stack trace pretty printer for C++.
+Version: 0.1
+Requires: 
+Libs: -L${libdir} -l /usr/lib/x86_64-linux-gnu/libdw.so
+Cflags: -I${includedir} 
+

--- a/test/test_pkgconfig/execution-proxies.pc
+++ b/test/test_pkgconfig/execution-proxies.pc
@@ -1,0 +1,24 @@
+# Generated from orogen/lib/orogen/templates/proxies/proxies.pc
+
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=${prefix}
+libdir=${prefix}/lib/orocos
+includedir=${prefix}/include/orocos
+
+
+
+project_name=execution
+deffile=${prefix}/share/orogen/execution.orogen
+task_models=execution::CNDHandler,execution::ProcessServer
+typekits=execution base orocos std
+
+Name: executionTasks
+Version: 0.1
+Description: tasks defined for the execution project
+Requires: orocos_cpp_base  execution-typekit-gnulinux execution-transport-corba-gnulinux execution-transport-mqueue-gnulinux execution-transport-typelib-gnulinux std-typekit-gnulinux std-transport-corba-gnulinux std-transport-mqueue-gnulinux std-transport-typelib-gnulinux base-typekit-gnulinux base-transport-corba-gnulinux base-transport-mqueue-gnulinux base-transport-typelib-gnulinux orocos_cpp_base
+
+
+Libs:  /media/wirkus/Data/development/rock-runtime/install/lib/orocos/gnulinux/types/librtt-typekit-gnulinux.so /media/wirkus/Data/development/rock-runtime/install/lib/orocos/gnulinux/types/librtt-transport-corba-gnulinux.so /media/wirkus/Data/development/rock-runtime/install/lib/orocos/gnulinux/types/librtt-transport-mqueue-gnulinux.so  -L${libdir} -lexecution-proxies
+
+Cflags: -I${includedir} -DOROCOS_TARGET=gnulinux -I/media/wirkus/Data/development/rock-runtime/install/include -I/media/wirkus/Data/development/rock-runtime/install/include/orocos -I/media/wirkus/Data/development/rock-runtime/install/include/orocos/base/types -I/usr/include/eigen3 -I/media/wirkus/Data/development/rock-runtime/install/include/orocos/std/types -I/media/wirkus/Data/development/rock-runtime/install/include/orocos/logger/types -I${includedir}/execution/types -I/media/wirkus/Data/development/rock-runtime/install/include -DOROCOS_TARGET=gnulinux -I/media/wirkus/Data/development/rock-runtime/install/include/orocos -I/media/wirkus/Data/development/rock-runtime/install/include/orocos/std/types -I/media/wirkus/Data/development/rock-runtime/install/include -DOROCOS_TARGET=gnulinux -I/usr/include/eigen3 -I/media/wirkus/Data/development/rock-runtime/install/include/orocos -I/media/wirkus/Data/development/rock-runtime/install/include/orocos/std/types -I/media/wirkus/Data/development/rock-runtime/install/include/orocos/base/types
+

--- a/test/test_pkgconfig/execution-tasks-gnulinux.pc
+++ b/test/test_pkgconfig/execution-tasks-gnulinux.pc
@@ -1,0 +1,23 @@
+# Generated from orogen/lib/orogen/templates/tasks/tasks.pc
+
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=${prefix}
+libdir=${prefix}/lib/orocos
+includedir=${prefix}/include/orocos
+
+
+
+project_name=execution
+deffile=${prefix}/share/orogen/execution.orogen
+task_models=execution::CNDHandler,execution::ProcessServer
+typekits=execution base orocos std
+
+Name: executionTasks
+Version: 0.1
+Description: tasks defined for the execution oroGen project
+Requires: 
+
+Libs:  -L${libdir} -lexecution-tasks-gnulinux
+
+Cflags: -I${includedir} -I/media/wirkus/Data/development/rock-runtime/install/include -DOROCOS_TARGET=gnulinux -I/media/wirkus/Data/development/rock-runtime/install/include/orocos -I/media/wirkus/Data/development/rock-runtime/install/include/orocos/std/types -I/usr/include/eigen3 -I/media/wirkus/Data/development/rock-runtime/install/include/orocos/base/types -I/media/wirkus/Data/development/rock-runtime/install/include/orocos/logger/types -I${includedir}/execution/types
+

--- a/test/test_pkgconfig/orocos-rtt-gnulinux.pc
+++ b/test/test_pkgconfig/orocos-rtt-gnulinux.pc
@@ -1,0 +1,11 @@
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=${prefix}  # defining another variable in terms of the first
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Orocos-RTT                          # human-readable name
+Description: Open Robot Control Software: Real-Time Tookit # human-readable description
+Version: 2.8.99
+Libs: -L${libdir} -lorocos-rtt-gnulinux  -L/usr/lib/x86_64-linux-gnu -lpthread -lrt  # If some RTT headers include inline calls to other libraries, we need to specify these here too.
+Libs.private:  -L/usr/lib/x86_64-linux-gnu -lboost_filesystem -L/usr/lib/x86_64-linux-gnu -lboost_system -L/usr/lib/x86_64-linux-gnu -lboost_serialization -L/usr/lib/x86_64-linux-gnu -lxerces-c -L/usr/lib/x86_64-linux-gnu -lpthread -lrt -ldl
+Cflags: -I${includedir}  -DOROCOS_TARGET=gnulinux  

--- a/test/test_pkgconfig/orogen-ping_pong_aba_a.pc
+++ b/test/test_pkgconfig/orogen-ping_pong_aba_a.pc
@@ -1,0 +1,16 @@
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=${prefix}
+libdir=${prefix}/lib/orocos
+includedir=${prefix}/include/orocos
+binfile=${prefix}/bin/ping_pong_aba_a
+
+project_name=rrt_evaluation_deployments
+deffile=${prefix}/share/orogen/rrt_evaluation_deployments.orogen
+typekits= base rock_runtime_evaluation std
+deployed_tasks=consumer,producer
+deployed_tasks_with_models=consumer,rock_runtime_evaluation::MessageConsumer,producer,rock_runtime_evaluation::MessageProducer
+
+Name: ping_pong_aba_a
+Version: 0.0
+Description: the static deployment defined for the ping_pong_aba_a deployment
+

--- a/test/test_pkgconfig/orogen-project-aggregator.pc
+++ b/test/test_pkgconfig/orogen-project-aggregator.pc
@@ -1,0 +1,12 @@
+prefix=/media/wirkus/Data/development/rock-runtime/install
+exec_prefix=${prefix}
+libdir=${prefix}/lib/orocos
+includedir=${prefix}/include/orocos
+
+project_name=aggregator
+deffile=${prefix}/share/orogen/aggregator.orogen
+type_registry=${prefix}/share/orogen/aggregator.tlb
+
+Name: aggregator
+Version: 0.0
+Description: the definition file for the orogen project itself

--- a/test/test_pkgconfig/test-typekit-gnulinux.pc
+++ b/test/test_pkgconfig/test-typekit-gnulinux.pc
@@ -1,0 +1,21 @@
+# Generated from orogen/lib/orogen/templates/typekit/typekit.pc
+
+prefix=/my/prefix
+exec_prefix=${prefix}
+libdir=${prefix}/lib/orocos/types
+includedir=${prefix}/include/orocos
+
+project_name=test
+deffile=${prefix}/share/orogen/test.orogen
+type_registry=${prefix}/share/orogen/test.tlb
+typekits= base test std
+deployed_tasks=consumer,producer,relay
+deployed_tasks_with_models=consumer,my::Consumer,producer,my::Producer
+
+Name: testTypekit
+Version: 0.0
+Requires: test
+Description: test types support for the Orocos type system
+Libs: -L${libdir} -ltest-typekit-gnulinux
+Cflags: -I${includedir} -I${includedir}/test/types "-DOROCOS_TARGET=gnulinux"
+

--- a/test/test_pkgconfig_helper.cpp
+++ b/test/test_pkgconfig_helper.cpp
@@ -1,0 +1,107 @@
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_MODULE "test_pkgconfig_helper"
+#define BOOST_AUTO_TEST_MAIN
+
+#include <boost/bind.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/execution_monitor.hpp>
+
+#include <orocos_cpp/PkgConfigHelper.hpp>
+#include <stdlib.h>
+
+using namespace orocos_cpp;
+
+BOOST_AUTO_TEST_CASE(parsePkgConfig)
+{
+    std::vector< std::pair<std::string,std::string> > expected_properties = {
+        std::pair<std::string,std::string>("Name","testTypekit"),
+        std::pair<std::string,std::string>("Version", "0.0"),
+        std::pair<std::string,std::string>("Requires", "test"),
+        std::pair<std::string,std::string>("Description", "test types support for the Orocos type system"),
+        std::pair<std::string,std::string>("Libs", "-L/my/prefix/lib/orocos/types -ltest-typekit-gnulinux"),
+        std::pair<std::string,std::string>("Cflags", "-I/my/prefix/include/orocos -I/my/prefix/include/orocos/test/types \"-DOROCOS_TARGET=gnulinux\"")
+    };
+    std::vector< std::pair<std::string,std::string> > expected_variables = {
+        std::pair<std::string,std::string>("prefix","/my/prefix"),
+        std::pair<std::string,std::string>("exec_prefix", "/my/prefix"),
+        std::pair<std::string,std::string>("libdir", "/my/prefix/lib/orocos/types"),
+        std::pair<std::string,std::string>("includedir", "/my/prefix/include/orocos"),
+        std::pair<std::string,std::string>("project_name", "test"),
+        std::pair<std::string,std::string>("deffile", "/my/prefix/share/orogen/test.orogen"),
+        std::pair<std::string,std::string>("type_registry", "/my/prefix/share/orogen/test.tlb"),
+        std::pair<std::string,std::string>("typekits", " base test std"),
+        std::pair<std::string,std::string>("deployed_tasks", "consumer,producer,relay"),
+        std::pair<std::string,std::string>("deployed_tasks_with_models", "consumer,my::Consumer,producer,my::Producer"),
+    };
+
+
+    int ret = putenv("PKG_CONFIG_PATH=../../test/test_pkgconfig");
+    std::map<std::string,std::string> variables;
+    std::map<std::string,std::string> properties;
+    bool st = PkgConfigHelper::parsePkgConfig("test-typekit-gnulinux.pc", variables, properties, false);
+    BOOST_CHECK(st);
+
+    BOOST_ASSERT(variables.size() == expected_variables.size());
+
+    for(size_t i=0; i<variables.size(); i++){
+        std::pair<std::string,std::string> expected = expected_variables[i];
+        std::map<std::string,std::string>::iterator it = variables.find(expected.first);
+        BOOST_ASSERT(it != variables.end());
+        BOOST_CHECK_EQUAL(it->second, expected.second);
+    }
+
+    BOOST_ASSERT(properties.size() == expected_properties.size());
+    for(size_t i=0; i<properties.size(); i++){
+        std::pair<std::string,std::string> expected = expected_properties[i];
+        std::map<std::string,std::string>::iterator it = properties.find(expected.first);
+        BOOST_ASSERT(it != properties.end());
+        BOOST_CHECK_EQUAL(it->second, expected.second);
+    }
+
+    BOOST_CHECK(st);
+}
+
+BOOST_AUTO_TEST_CASE(oldParsePkgConfigStillWorking)
+{
+    std::vector< std::pair<std::string,std::string> > expected_properties = {
+        std::pair<std::string,std::string>("Description", "test types support for the Orocos type system"),
+        std::pair<std::string,std::string>("Libs", "-L/my/prefix/lib/orocos/types -ltest-typekit-gnulinux")
+    };
+    std::vector< std::pair<std::string,std::string> > expected_variables = {
+        std::pair<std::string,std::string>("type_registry", "/my/prefix/share/orogen/test.tlb"),
+        std::pair<std::string,std::string>("deployed_tasks", "consumer,producer,relay"),
+        std::pair<std::string,std::string>("deployed_tasks_with_models", "consumer,my::Consumer,producer,my::Producer")
+    };
+
+    int ret = putenv("PKG_CONFIG_PATH=../../test/test_pkgconfig");
+    std::vector<std::string> fields={"type_registry", "deployed_tasks", "deployed_tasks_with_models"};
+    std::vector<std::string> res;
+
+    bool st = PkgConfigHelper::parsePkgConfig("test-typekit-gnulinux.pc", fields, res, false);
+    BOOST_CHECK(st);
+
+    BOOST_ASSERT(fields.size() == res.size());
+    BOOST_ASSERT(res.size() == expected_variables.size());
+
+    for(size_t i=0; i<fields.size(); i++){
+        std::pair<std::string,std::string> expected = expected_variables[i];
+        std::string val = res[i];
+        BOOST_CHECK_EQUAL(val, expected.second);
+    }
+
+    fields={"gibt'snicht"};
+    st = PkgConfigHelper::parsePkgConfig("test-typekit-gnulinux.pc", fields, res, false);
+    BOOST_CHECK(!st);
+
+
+    fields={"Description", "Libs"};
+    st = PkgConfigHelper::parsePkgConfig("test-typekit-gnulinux.pc", fields, res, true);
+    BOOST_CHECK(st);
+
+    BOOST_ASSERT(res.size() == expected_properties.size());
+    for(size_t i=0; i<res.size(); i++){
+        std::pair<std::string,std::string> expected = expected_properties[i];
+        std::string val = res[i];
+        BOOST_CHECK_EQUAL(val, expected.second);
+    }
+}

--- a/test/test_pkgconfig_helper.cpp
+++ b/test/test_pkgconfig_helper.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(parsePkgConfig)
         std::pair<std::string,std::string>("project_name", "test"),
         std::pair<std::string,std::string>("deffile", "/my/prefix/share/orogen/test.orogen"),
         std::pair<std::string,std::string>("type_registry", "/my/prefix/share/orogen/test.tlb"),
-        std::pair<std::string,std::string>("typekits", " base test std"),
+        std::pair<std::string,std::string>("typekits", "base test std"),
         std::pair<std::string,std::string>("deployed_tasks", "consumer,producer,relay"),
         std::pair<std::string,std::string>("deployed_tasks_with_models", "consumer,my::Consumer,producer,my::Producer"),
     };

--- a/test/test_pkgconfig_registry.cpp
+++ b/test/test_pkgconfig_registry.cpp
@@ -1,0 +1,66 @@
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_MODULE "test_pkgconfig_helper"
+#define BOOST_AUTO_TEST_MAIN
+
+#include <boost/bind.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/execution_monitor.hpp>
+
+#include <orocos_cpp/PkgConfigRegistry.hpp>
+#include <stdlib.h>
+
+using namespace orocos_cpp;
+
+BOOST_AUTO_TEST_CASE(parsePkgConfig)
+{
+    int ret = putenv("PKG_CONFIG_PATH=../../test/test_pkgconfig");
+    PkgConfigRegistry reg;
+    reg.initialize();
+
+    PkgConfig pkg;
+    BOOST_CHECK(reg.getDeployment("ping_pong_aba_a", pkg));
+    std::string val;
+    BOOST_CHECK(pkg.getVariable("project_name", val));
+    BOOST_CHECK_EQUAL(val, "rrt_evaluation_deployments");
+
+
+    TypekitPkgConfig typ;
+    BOOST_CHECK(reg.getTypekit("aggregator", typ));
+    BOOST_ASSERT(typ.transports.size() == 3);
+    pkg = typ.transports["corba"];
+    BOOST_CHECK(pkg.getProperty("Name", val));
+    BOOST_CHECK_EQUAL(val, "aggregatorCorbaTransport");
+    pkg = typ.transports["mqueue"];
+    BOOST_CHECK(pkg.getProperty("Name", val));
+    BOOST_CHECK_EQUAL(val, "aggregatorMQueueTransport");
+    pkg = typ.transports["typelib"];
+    BOOST_CHECK(pkg.getProperty("Name", val));
+    BOOST_CHECK_EQUAL(val, "aggregatorTypelibTransport");
+
+    BOOST_CHECK(typ.typekit.getProperty("Name", val));
+    BOOST_CHECK_EQUAL(val, "aggregatorTypekit");
+
+    OrogenPkgConfig oro;
+    BOOST_CHECK(reg.getOrogen("aggregator", oro));
+    BOOST_CHECK(oro.project.getProperty("Description", val));
+    BOOST_CHECK_EQUAL(val, "the definition file for the orogen project itself");
+    BOOST_CHECK(!oro.proxies.isLoaded()); //Not present in folder
+    BOOST_CHECK(!oro.tasks.isLoaded()); //Not present in folder
+
+    BOOST_CHECK(reg.getOrogen("execution", oro));
+    BOOST_CHECK(!oro.project.isLoaded()); //Not present in folder
+    BOOST_CHECK(oro.proxies.isLoaded());
+    BOOST_CHECK(oro.tasks.isLoaded());
+
+    std::vector<std::string> expected_orogen = {"aggregator", "execution"};
+    std::vector<std::string> expected_deployments = {"ping_pong_aba_a"};
+    std::vector<std::string> expected_typekits = {"aggregator", "test"};
+
+    std::vector<std::string> regoro = reg.getRegisteredOrogenNames();
+    BOOST_CHECK(regoro == expected_orogen);
+    std::vector<std::string> regdep = reg.getRegisteredDeploymentNames();
+    BOOST_CHECK(regdep == expected_deployments);
+    std::vector<std::string> regtyp = reg.getRegisteredTypekitNames();
+    BOOST_CHECK(regtyp == expected_typekits);
+}
+


### PR DESCRIPTION
* new class PkgConfigRegistry with singleton access. It parses all pkgconfig files for rock tasks/deployments/typekits and stores the content once on intialization
* TypeRegistry, Deployment and PluginHelper are adapted accordingly

Old implementation led to many unnecessary file i/o operations during runtime.