### PR TITLE
Rename default tasks text log files to the task name

### DIFF
--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -93,7 +93,7 @@ Spawner& Spawner::getInstace()
 }
 
 
-Spawner::ProcessHandle::ProcessHandle(Deployment *deploment, bool redirectOutputv, const std::string &logDir) : isRunning(true), deployment(deploment)
+Spawner::ProcessHandle::ProcessHandle(Deployment *deployment, bool redirectOutputv, const std::string &logDir, const std::string textLogFileName = "") : isRunning(true), deployment(deployment)
 {
     std::string cmd;
     std::vector< std::string > args;
@@ -128,7 +128,7 @@ Spawner::ProcessHandle::ProcessHandle(Deployment *deploment, bool redirectOutput
             throw std::runtime_error("Spawner : ProcessHandle could not unblock SIGINT");
         }
             
-        processName = deploment->getName();
+        processName = deployment->getName();
         return;
     }
 
@@ -145,15 +145,15 @@ Spawner::ProcessHandle::ProcessHandle(Deployment *deploment, bool redirectOutput
         {
             throw std::runtime_error("Error, log directory '" + logDir + "' does not exist, but it should !");
         }
-        processName = deploment->getName();
+        processName = deployment->getName();
 
-        if(processName.find("orogen_default_") == 0)
+        if (!textLogFileName.empty())
         {
-            redirectOutput(logDir + "/" + deployment->getTaskNames().at(0) + ".txt");            
+            redirectOutput(logDir + "/" + textLogFileName + "-" + boost::lexical_cast<std::string>(getpid()) + ".txt");
         }
         else
         {
-            redirectOutput(logDir + "/" + processName + ".txt");    
+            redirectOutput(logDir + "/" + processName + "-" + boost::lexical_cast<std::string>(getpid()) + ".txt");
         }
     }
     
@@ -281,7 +281,7 @@ Spawner::ProcessHandle &Spawner::spawnTask(const std::string& cmp1, const std::s
     return spawnDeployment(dpl, redirectOutput);
 }
 
-Spawner::ProcessHandle& Spawner::spawnDeployment(Deployment* deployment, bool redirectOutput)
+Spawner::ProcessHandle& Spawner::spawnDeployment(Deployment* deployment, bool redirectOutput, const std::string textLogFileName)
 {
     if(redirectOutput && logDir.empty())
     {
@@ -289,7 +289,7 @@ Spawner::ProcessHandle& Spawner::spawnDeployment(Deployment* deployment, bool re
         logDir = Bundle::getInstance().getLogDirectory();
     }
 
-    ProcessHandle *handle = new ProcessHandle(deployment, redirectOutput, logDir);
+    ProcessHandle *handle = new ProcessHandle(deployment, redirectOutput, logDir, textLogFileName);
     
     handles.push_back(handle);
 
@@ -301,11 +301,11 @@ Spawner::ProcessHandle& Spawner::spawnDeployment(Deployment* deployment, bool re
     return *handle;
 }
 
-Spawner::ProcessHandle& Spawner::spawnDeployment(const std::string& dplName, bool redirectOutput)
+Spawner::ProcessHandle& Spawner::spawnDeployment(const std::string& dplName, bool redirectOutput, const std::string textLogFileName)
 {
-    Deployment *deploment = new Deployment(dplName);
+    Deployment *deployment = new Deployment(dplName);
 
-    return spawnDeployment(deploment, redirectOutput);
+    return spawnDeployment(deployment, redirectOutput, textLogFileName);
 }
 
 bool Spawner::checkAllProcesses()

--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -149,7 +149,7 @@ Spawner::ProcessHandle::ProcessHandle(Deployment *deployment, bool redirectOutpu
 
         if (!textLogFileName.empty())
         {
-            redirectOutput(logDir + "/" + textLogFileName + "-" + boost::lexical_cast<std::string>(getpid()) + ".txt");
+            redirectOutput(logDir + "/" + textLogFileName + ".txt");
         }
         else
         {

--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -93,7 +93,7 @@ Spawner& Spawner::getInstace()
 }
 
 
-Spawner::ProcessHandle::ProcessHandle(Deployment *deployment, bool redirectOutputv, const std::string &logDir, const std::string textLogFileName = "") : isRunning(true), deployment(deployment)
+Spawner::ProcessHandle::ProcessHandle(Deployment *deployment, bool redirectOutputv, const std::string &logDir, const std::string textLogFileName) : isRunning(true), deployment(deployment)
 {
     std::string cmd;
     std::vector< std::string > args;

--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -146,7 +146,15 @@ Spawner::ProcessHandle::ProcessHandle(Deployment *deploment, bool redirectOutput
             throw std::runtime_error("Error, log directory '" + logDir + "' does not exist, but it should !");
         }
         processName = deploment->getName();
-        redirectOutput(logDir + "/" + processName + "-" + boost::lexical_cast<std::string>(getpid()) + ".txt");
+
+        if(processName.find("orogen_default_") == 0)
+        {
+            redirectOutput(logDir + "/" + deployment->getTaskNames().at(0) + ".txt");            
+        }
+        else
+        {
+            redirectOutput(logDir + "/" + processName + ".txt");    
+        }
     }
     
     //do the exec

--- a/src/Spawner.hpp
+++ b/src/Spawner.hpp
@@ -37,7 +37,7 @@ public:
         
         Deployment *deployment;
     public:
-        ProcessHandle(Deployment *deployment, bool redirectOutput, const std::string &logDir);
+        ProcessHandle(Deployment *deployment, bool redirectOutput, const std::string &logDir, const std::string textLogFileName);
         
         const Deployment &getDeployment() const;
         bool alive() const;
@@ -73,7 +73,7 @@ public:
      * @arg dplName Name of the deployment executable that should be started
      * @return  A Process handle, which may be used to request the process status
      * */
-    ProcessHandle &spawnDeployment(const std::string &dplName, bool redirectOutput = true);
+    ProcessHandle &spawnDeployment(const std::string &dplName, bool redirectOutput = true, const std::string textLogFileName = "");
 
     /**
      * This method spawns a process that executes the given 
@@ -83,7 +83,7 @@ public:
      * @arg dplName The deployment that should be started. The ownership of the deployment will be taken over by the spawner.
      * @return  A Process handle, which may be used to request the process status
      * */
-    ProcessHandle &spawnDeployment(Deployment *deployment, bool redirectOutput = true);
+    ProcessHandle &spawnDeployment(Deployment *deployment, bool redirectOutput = true, const std::string textLogFileName = "");
     
     /**
      * This method checks if all spawened processes are still alive

--- a/src/Spawner.hpp
+++ b/src/Spawner.hpp
@@ -37,7 +37,7 @@ public:
         
         Deployment *deployment;
     public:
-        ProcessHandle(Deployment *deployment, bool redirectOutput, const std::string &logDir, const std::string textLogFileName);
+        ProcessHandle(Deployment *deployment, bool redirectOutput, const std::string &logDir, const std::string textLogFileName = "");
         
         const Deployment &getDeployment() const;
         bool alive() const;

--- a/src/Spawner.hpp
+++ b/src/Spawner.hpp
@@ -57,30 +57,38 @@ public:
     /**
      * This method spawns a default deployment matching the given componente description.
      * If a second argument is given, the task will be renamed to the given name.
+     * If a third argument is given, the task text logs will be redirected to the bundle log folder.
      * The method will throw if any error occures.
      * 
      * @arg cmp1 The task model name e.g Hokuyo::Task 
      * @arg as The name unter wich the taskmodel should be registered a the nameservice
+     * @arg redirectOutput flag about whether the deployment text log files should be redirected
      * @return A Process handle, which may be used to request the process status
      * */
     ProcessHandle &spawnTask(const std::string &cmp1, const std::string &as = std::string(), bool redirectOutput = true);
     
     /**
-     * This method spawns a process that executes the deployment
-     * with the given name. This method will throw if any error
-     * occures.
+     * This method spawns a process that executes the deployment with the given name.
+     * This method will throw if any error occures.
+     * If a second argument is given, the task text logs will be redirected to the bundle log folder.
+     * If a third argument is given then this argument will be used as the name of the text log file.
      * 
      * @arg dplName Name of the deployment executable that should be started
+     * @arg redirectOutput flag about whether the deployment text log files should be redirected
+     * @arg textLogFileName Name (without .txt extension) of the output deployment text log file
      * @return  A Process handle, which may be used to request the process status
      * */
     ProcessHandle &spawnDeployment(const std::string &dplName, bool redirectOutput = true, const std::string textLogFileName = "");
 
     /**
-     * This method spawns a process that executes the given 
-     * deployment. This method will throw if any error
-     * occures.
+     * This method spawns a process that executes the given deployment.
+     * This method will throw if any error occures.
+     * If a second argument is given, the task text logs will be redirected to the bundle log folder.
+     * If a third argument is given then this argument will be used as the name of the text log file.
      * 
      * @arg dplName The deployment that should be started. The ownership of the deployment will be taken over by the spawner.
+     * @arg redirectOutput flag about whether the deployment text log files should be redirected
+     * @arg textLogFileName Name (without .txt extension) of the output deployment text log file
      * @return  A Process handle, which may be used to request the process status
      * */
     ProcessHandle &spawnDeployment(Deployment *deployment, bool redirectOutput = true, const std::string textLogFileName = "");


### PR DESCRIPTION
Hello,

we wanted to rename to the text log files for the default deployments to contain the task name defined in the cnd file and not the process name. Since the default deployment in the cnd has just one task in the tasklist so we just take the 0th element of the tasks vector

The complex deployments still use the process name.

Best,
Haider