### PR TITLE
Pkg config free deployments

### DIFF
--- a/src/Deployment.cpp
+++ b/src/Deployment.cpp
@@ -10,14 +10,16 @@
 
 using namespace orocos_cpp;
 
-Deployment::Deployment(const std::string& name) : deploymentName(name), withValgrind(false)
+Deployment::Deployment(const std::string& name, bool load_pkg_config) : deploymentName(name), withValgrind(false)
 {
-    loadPkgConfigFile(name);
+    if(load_pkg_config){
+        loadPkgConfigFile(name);
+    }
     if(!checkExecutable(name))
         throw std::runtime_error("Deployment::Error, executable for deployment '" + name + "' could not be found in PATH");
 }
 
-Deployment::Deployment(const std::string &cmp1, const std::string &as) : withValgrind(false)
+Deployment::Deployment(const std::string &cmp1, const std::string &as, bool load_pkg_config) : withValgrind(false)
 {
     //cmp1 is expected in the format "module::TaskSpec"
     std::string::size_type pos = cmp1.find_first_of(":");
@@ -32,11 +34,14 @@ Deployment::Deployment(const std::string &cmp1, const std::string &as) : withVal
     std::string defaultDeploymentName = "orogen_default_" + moduleName + "__" + taskModelName;
     
     deploymentName = defaultDeploymentName;
-    try {
-        loadPkgConfigFile(deploymentName);
-    } catch (const std::runtime_error &e)
-    {
-        throw std::runtime_error("Deployment::Error, could not find pkgConfig file for deployment " + deploymentName);
+    if(load_pkg_config){
+        try {
+            loadPkgConfigFile(deploymentName);
+        }
+        catch (const std::runtime_error &e)
+        {
+            throw std::runtime_error("Deployment::Error, could not find pkgConfig file for deployment " + deploymentName);
+        }
     }
     if(!checkExecutable(deploymentName))
         throw std::runtime_error("Deployment::Error, executable for deployment " + deploymentName + " could not be found in PATH");
@@ -147,7 +152,7 @@ const std::vector< std::string >& Deployment::getNeededTypekits() const
 
 void Deployment::renameTask(const std::string& orignalName, const std::string& newName)
 {
-    auto it = renameMap.find(orignalName);
+    /*auto it = renameMap.find(orignalName);
     if(it == renameMap.end())
     {
         throw std::out_of_range("Deployment::renameTask : Error, deployment " + deploymentName + " has no task " + orignalName);
@@ -155,8 +160,8 @@ void Deployment::renameTask(const std::string& orignalName, const std::string& n
     
     //set new name
     std::string origName = it->second;
-    renameMap.erase(it);
-    renameMap[newName] = origName;
+    renameMap.erase(it);*/
+    renameMap[newName] = orignalName;
 
     //regenerate the task list
     regenerateNameVectors();

--- a/src/Deployment.cpp
+++ b/src/Deployment.cpp
@@ -159,8 +159,6 @@ void Deployment::renameTask(const std::string& orignalName, const std::string& n
                throw std::out_of_range("Deployment::renameTask : Error, deployment " + deploymentName + " has no task " + orignalName);
         }
 
-        //set new name
-        std::string origName = it->second;
         renameMap.erase(it);
     }
 

--- a/src/Deployment.cpp
+++ b/src/Deployment.cpp
@@ -152,15 +152,6 @@ const std::vector< std::string >& Deployment::getNeededTypekits() const
 
 void Deployment::renameTask(const std::string& orignalName, const std::string& newName)
 {
-    /*auto it = renameMap.find(orignalName);
-    if(it == renameMap.end())
-    {
-        throw std::out_of_range("Deployment::renameTask : Error, deployment " + deploymentName + " has no task " + orignalName);
-    }
-    
-    //set new name
-    std::string origName = it->second;
-    renameMap.erase(it);*/
     renameMap[newName] = orignalName;
 
     //regenerate the task list

--- a/src/Deployment.cpp
+++ b/src/Deployment.cpp
@@ -150,8 +150,20 @@ const std::vector< std::string >& Deployment::getNeededTypekits() const
     return typekits;
 }
 
-void Deployment::renameTask(const std::string& orignalName, const std::string& newName)
+void Deployment::renameTask(const std::string& orignalName, const std::string& newName, bool check_existence_in_rename_map)
 {
+    if(check_existence_in_rename_map){
+        auto it = renameMap.find(orignalName);
+        if(it == renameMap.end())
+        {
+               throw std::out_of_range("Deployment::renameTask : Error, deployment " + deploymentName + " has no task " + orignalName);
+        }
+
+        //set new name
+        std::string origName = it->second;
+        renameMap.erase(it);
+    }
+
     renameMap[newName] = orignalName;
 
     //regenerate the task list

--- a/src/Deployment.hpp
+++ b/src/Deployment.hpp
@@ -30,9 +30,9 @@ private:
     std::vector<std::string> cmdLineArgs;
     
 public:
-    Deployment(const std::string &name);
+    Deployment(const std::string &name, bool load_pkgconfig=true);
     
-    Deployment(const std::string &model, const std::string &as);
+    Deployment(const std::string &model, const std::string &as, bool load_pkgconfig=true);
     
     /**
      * Returns the name of the deployment

--- a/src/Deployment.hpp
+++ b/src/Deployment.hpp
@@ -51,7 +51,7 @@ public:
      *
      * @throws std::out_of_range when originalName does not exist
      * */
-    void renameTask(const std::string &orignalName, const std::string &newName);
+    void renameTask(const std::string &orignalName, const std::string &newName, bool check_existence_in_rename_map=true);
 
     /**
      * Returns the command line string, needed to 

--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -65,7 +65,6 @@ void shutdownHandler(int signum, siginfo_t *info, void *data)
     }
     restoreSignalHandler(signum);
     raise(signum);
-    
 }
 
 Spawner::Spawner()
@@ -101,13 +100,6 @@ Spawner::ProcessHandle::ProcessHandle(Deployment *deployment, bool redirectOutpu
     if(!deployment->getExecString(cmd, args))
         throw std::runtime_error("Error, could not get parameters to start deployment " + deployment->getName() );
     
-    /* Block SIGINT. */
-    sigset_t mask, omask;
-    sigemptyset(&mask);
-    sigaddset(&mask, SIGINT);
-    if(sigprocmask(SIG_BLOCK, &mask, &omask))
-        throw std::runtime_error("Spawner : ProcessHandle could not block SIGINT");
-    
     pid = fork();
     
     if(pid < 0)
@@ -121,11 +113,6 @@ Spawner::ProcessHandle::ProcessHandle(Deployment *deployment, bool redirectOutpu
         if (setpgid(pid, pid) < 0 && errno != EACCES)
         {
             throw std::runtime_error("Spawner : ProcessHandle: Parent : Error changing process group of child");
-        }
-        
-        if(sigprocmask(SIG_SETMASK, &omask, NULL))
-        {
-            throw std::runtime_error("Spawner : ProcessHandle could not unblock SIGINT");
         }
             
         processName = deployment->getName();


### PR DESCRIPTION
* Add mode to orocos_cpp's Deployment to skip loading of PkgConfig files. By default it was trying to find pkg config files that are associated to a Deployment by applying file naming conventions
* In orocos_cpp Deployment, make check of existence check for "old" names in renaming  optional