### PR TITLE
Use backward correctly.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package( Boost COMPONENTS thread system filesystem regex)
+find_package( Backward REQUIRED)
 rock_library(orocos_cpp
     SOURCES 
         ConfigurationHelper.cpp
@@ -38,9 +39,12 @@ rock_library(orocos_cpp
         typelib
         lib_config
         base-logging
-        backward
     DEPS
-        Boost::system Boost::filesystem Boost::regex Boost::thread
+        Boost::system
+        Boost::filesystem
+        Boost::regex
+        Boost::thread
+        Backward::Interface
     )
 
 rock_executable(listAll Main.cpp

--- a/src/Spawner.cpp
+++ b/src/Spawner.cpp
@@ -17,7 +17,7 @@
 #include "CorbaNameService.hpp"
 #include <lib_config/Bundle.hpp>
 #include <signal.h>
-#include <backward/backward.hpp>
+#include <backward.hpp>
 #include <rtt/transports/corba/TaskContextProxy.hpp>
 #include <base-logging/Logging.hpp>
 


### PR DESCRIPTION
This will allow to use the current version of tools/backward-cpp without patching it.

@planthaber 